### PR TITLE
Add reference to global object for resolve default context

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     },
     "env": {},
     "globals": {
+        "global": true,
         "require": true,
         "module": true
     },

--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -1,0 +1,9 @@
+/**
+ * @module lib/global
+ * @since 1.1.0
+ * @description exposes the global object (self | global | window)
+ */
+
+module.exports = (typeof self === 'object' && self.self === self && self) ||
+    (typeof global === 'object' && global.global === global && global) ||
+    (typeof window === 'object' && window.window === window && window);

--- a/lib/global/test.js
+++ b/lib/global/test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('chai').assert;
+const _global = require('./');
+
+describe('_global', () => {
+
+  global.data_member = 'a value';
+
+  it('Exports an object', () => assert.equal(typeof _global, 'object'));
+
+  it('exposes the global object', (done) => {
+    const same = _global === global;
+
+    assert.equal(same, true);
+    done();
+  });
+
+  it('global and _global share the interface', (done) => {
+    assert.equal(_global.data_member, global.data_member);
+    done();
+  });
+
+});

--- a/lib/resolve/index.js
+++ b/lib/resolve/index.js
@@ -3,6 +3,8 @@
  * @since 1.0.0
  */
 
+const _global = require('../global');
+
 /**
  * Resolve dot notation string
  *
@@ -12,14 +14,14 @@
  *
  * @example resolve('top_level.nested.value', data_object)
  */
-function resolve(string = '', context) {
+function resolve(string = '', context = _global) {
     if (typeof string !== 'string') {
         throw new TypeError(`commodity#resolve expects first argument to be a string, got a ${typeof string}`);
     }
 
     return string
         .split('.')
-        .reduce((previous, current) => typeof previous === 'object' ? previous[current] : previous, (context || this));
+        .reduce((previous, current) => typeof previous === 'object' ? previous[current] : previous, context);
 }
 
 module.exports = resolve;

--- a/lib/resolve/test.js
+++ b/lib/resolve/test.js
@@ -46,6 +46,18 @@ describe('resolve', () => {
     done();
   });
 
+  it('Resolves from global object when context is scoped', (done) => {
+    global.some = {nested: 'value'};
+
+    let commodity = {
+      resolve
+    };
+
+    const res = commodity.resolve('some.nested');
+    assert.equal(res, 'value');
+    done();
+  });
+
   it('Resolves missing data to \'undefined\'', (done) => {
     const res = resolve('missing.data', data_structure);
     assert.equal(res, undefined);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/commodity",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "Fiverr",
   "license": "MIT",
   "description": "Collection of low level Javascript helper functions targeting language primitives and native objects",

--- a/readme.md
+++ b/readme.md
@@ -73,5 +73,5 @@ The version number specify `major`.`minor`.`patch`
 Type | Content | Example
 ---- | ------- | -----------
 patch | Internal fix | Performance updates, tests, small tweaks
-minor | Interface change with full backward compatibility | Adding a new function
+minor | Interface change with full backward compatibility | Adding a new function, Bug fix
 major | Interface change without full backward compatibility | Changing a function name or output, Removing a function


### PR DESCRIPTION
Address issue #2 :
> **resolve does not default to global scope in context**
> When `resolve` is a member of an object (`commodity.resolve(...)`), the default context is non lexical and points to the current context (`commodity`).